### PR TITLE
Add autoscaler and binding samples for kubedb resources

### DIFF
--- a/aerospike/sample.yaml
+++ b/aerospike/sample.yaml
@@ -14,7 +14,7 @@ metadata:
   name: aerospike
   namespace: demo
 spec:
-  version: "7.2.0.7"
+  version: "8.1.2.2"
   mode: Cluster
   cluster:
     replicas: 3

--- a/aerospike/sample.yaml
+++ b/aerospike/sample.yaml
@@ -1,0 +1,49 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: aerospike-auth
+  namespace: demo
+stringData:
+  password: thisIs1StrongPassword
+  username: root
+type: Opaque
+---
+apiVersion: kubedb.com/v1alpha2
+kind: Aerospike
+metadata:
+  name: aerospike
+  namespace: demo
+spec:
+  version: "7.2.0.7"
+  mode: Cluster
+  cluster:
+    replicas: 3
+    replicationFactor: 2
+  authSecret:
+    name: aerospike-auth
+  deletionPolicy: WipeOut
+---
+apiVersion: autoscaling.kubedb.com/v1alpha1
+kind: AerospikeAutoscaler
+metadata:
+  name: aerospike
+  namespace: demo
+spec:
+  databaseRef:
+    name: aerospike
+  opsRequestOptions:
+    timeout: 10m
+    apply: IfReady
+  compute:
+    aerospike:
+      trigger: "On"
+      podLifeTimeThreshold: 10m
+      resourceDiffPercentage: 20
+      minAllowed:
+        cpu: 400m
+        memory: 400Mi
+      maxAllowed:
+        cpu: 1
+        memory: 2Gi
+    nodeTopology:
+      name: standard-basv2-family

--- a/db2/sample/db2.yaml
+++ b/db2/sample/db2.yaml
@@ -61,3 +61,28 @@ spec:
     - alias: primary
       spec:
         type: LoadBalancer
+---
+apiVersion: autoscaling.kubedb.com/v1alpha1
+kind: DB2Autoscaler
+metadata:
+  name: db2
+  namespace: default
+spec:
+  databaseRef:
+    name: db2
+  opsRequestOptions:
+    timeout: 10m
+    apply: IfReady
+  compute:
+    db2:
+      trigger: "On"
+      podLifeTimeThreshold: 10m
+      resourceDiffPercentage: 20
+      minAllowed:
+        cpu: 400m
+        memory: 400Mi
+      maxAllowed:
+        cpu: 1
+        memory: 2Gi
+    nodeTopology:
+      name: standard-basv2-family

--- a/pgpool/pgpool.yaml
+++ b/pgpool/pgpool.yaml
@@ -168,3 +168,13 @@ spec:
         memory: 2Gi
     nodeTopology:
       name: standard-basv2-family
+---
+apiVersion: catalog.appscode.com/v1alpha1
+kind: PgpoolBinding
+metadata:
+  name: pgpool
+  namespace: demo
+spec:
+  sourceRef:
+    name: pgpool
+    namespace: demo

--- a/redissentinel/prometheus.io/tls/custom-auth/sample.yaml
+++ b/redissentinel/prometheus.io/tls/custom-auth/sample.yaml
@@ -111,3 +111,28 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: redis
       app.kubernetes.io/name: redises.kubedb.com
+---
+apiVersion: autoscaling.kubedb.com/v1alpha1
+kind: RedisSentinelAutoscaler
+metadata:
+  name: redissentinel
+  namespace: demo
+spec:
+  databaseRef:
+    name: redissentinel
+  opsRequestOptions:
+    timeout: 10m
+    apply: IfReady
+  compute:
+    sentinel:
+      trigger: "On"
+      podLifeTimeThreshold: 10m
+      resourceDiffPercentage: 20
+      minAllowed:
+        cpu: 400m
+        memory: 400Mi
+      maxAllowed:
+        cpu: 1
+        memory: 2Gi
+    nodeTopology:
+      name: standard-basv2-family

--- a/zookeeper/sample.yaml
+++ b/zookeeper/sample.yaml
@@ -301,3 +301,13 @@ spec:
         memory: 2Gi
     nodeTopology:
       name: standard-basv2-family
+---
+apiVersion: catalog.appscode.com/v1alpha1
+kind: ZooKeeperBinding
+metadata:
+  name: zookeeper
+  namespace: demo
+spec:
+  sourceRef:
+    name: zookeeper
+    namespace: demo


### PR DESCRIPTION
Audited all samples referenced in lib-app/kubedb.sh against the rule: every sample should have an Autoscaler, and a Binding CR where a catalog/v1alpha1 binding type exists.

## Changes
- `redissentinel`: add `RedisSentinelAutoscaler`
- `db2`: add `DB2Autoscaler`
- `pgpool`: add `PgpoolBinding`
- `zookeeper`: add `ZooKeeperBinding`
- `aerospike`: new `sample.yaml` with `Aerospike` (Cluster) + auth Secret + `AerospikeAutoscaler`

## Notes
- `vault` (VaultServer) has no autoscaler type in any apimachinery, so it was left unchanged.
- Aerospike version `7.2.0.7` is a placeholder; verify it matches an installed AerospikeVersion.
- DBs without a catalog binding type (documentdb, hanadb, ignite, milvus, neo4j, qdrant, weaviate, etc.) get no Binding CR, per the rule.