### PR TITLE
Add binding samples for Milvus, Qdrant, Weaviate

### DIFF
--- a/milvus/sample/milvus.yaml
+++ b/milvus/sample/milvus.yaml
@@ -130,3 +130,13 @@ spec:
         memory: 2Gi
     nodeTopology:
       name: standard-basv2-family
+---
+apiVersion: catalog.appscode.com/v1alpha1
+kind: MilvusBinding
+metadata:
+  name: milvus
+  namespace: demo
+spec:
+  sourceRef:
+    name: milvus
+    namespace: demo

--- a/qdrant/sample/qdrant.yaml
+++ b/qdrant/sample/qdrant.yaml
@@ -130,3 +130,13 @@ spec:
         memory: 2Gi
     nodeTopology:
       name: standard-basv2-family
+---
+apiVersion: catalog.appscode.com/v1alpha1
+kind: QdrantBinding
+metadata:
+  name: qdrant
+  namespace: demo
+spec:
+  sourceRef:
+    name: qdrant
+    namespace: demo

--- a/weaviate/sample/weaviate.yaml
+++ b/weaviate/sample/weaviate.yaml
@@ -98,3 +98,13 @@ spec:
         memory: 2Gi
     nodeTopology:
       name: standard-basv2-family
+---
+apiVersion: catalog.appscode.com/v1alpha1
+kind: WeaviateBinding
+metadata:
+  name: weaviate
+  namespace: demo
+spec:
+  sourceRef:
+    name: weaviate
+    namespace: demo


### PR DESCRIPTION
Adds the missing `catalog.appscode.com/v1alpha1` Binding CRs for the three supported databases that lacked them:

- `MilvusBinding` → milvus/sample/milvus.yaml
- `QdrantBinding` → qdrant/sample/qdrant.yaml
- `WeaviateBinding` → weaviate/sample/weaviate.yaml

Follows the existing convention from #76 (binding + sourceRef in `demo` namespace). The other 16 binding-supported DBs referenced in kubedb.sh already had their Binding CR.